### PR TITLE
Proposes a 1px separator between panels

### DIFF
--- a/Spacegray.sublime-theme
+++ b/Spacegray.sublime-theme
@@ -326,8 +326,8 @@
 
     {
         "class": "grid_layout_control",
-        "border_size": 0,
-        "border_color": [40,40,40]
+        "border_size": 1,
+        "border_color": [28,31,38]
     },
 
 //


### PR DESCRIPTION
When working with two panels side by side it's strange not having a visual separation between them.
I've added a 1px separator using the same color as status_bar background.
