### PR TITLE
Suggestion Invalid Color using base16

### DIFF
--- a/base16-ocean.dark.tmTheme
+++ b/base16-ocean.dark.tmTheme
@@ -500,7 +500,7 @@
 				<key>background</key>
 				<string>#bf616a</string>
 				<key>foreground</key>
-				<string>#505050</string>
+				<string>#b0b0b0</string>
 			</dict>
 		</dict>
 	</array>


### PR DESCRIPTION
Issue: https://github.com/kkga/spacegray/issues/53

Example: wrong and uncompleted JSON syntax.

``` json
{
    "Boolean": true,
    "xxx": qwerty,
    "uncompleted": i cant see }
```
