### PR TITLE
Fix non-overlay scrollbar colors in Spacegray

### DIFF
--- a/Spacegray Eighties.sublime-theme
+++ b/Spacegray Eighties.sublime-theme
@@ -201,7 +201,7 @@
     {
         "class": "scroll_bar_control",
         "layer0.texture": "",
-        "layer0.tint": [57, 57, 57], // 01
+        "layer0.tint": [38, 38, 38], // -01
         "layer0.opacity": 1,
         "layer0.inner_margin": [0,0],
         "blur": true
@@ -211,7 +211,7 @@
         "class": "scroll_bar_control",
         "attributes": ["horizontal"],
         "layer0.texture": "",
-        "layer0.tint": [57, 57, 57], // 01
+        "layer0.tint": [38, 38, 38], // -01
         "layer0.inner_margin": [0,0],
         "blur": true
     },
@@ -219,7 +219,7 @@
     {
         "class": "scroll_corner_control",
         "layer0.texture": "",
-        "layer0.tint": [57, 57, 57], // 01
+        "layer0.tint": [38, 38, 38], // -01
         "layer0.inner_margin": [0,0],
         "layer0.opacity": 1
     },

--- a/Spacegray Light.sublime-theme
+++ b/Spacegray Light.sublime-theme
@@ -202,7 +202,7 @@
     {
         "class": "scroll_bar_control",
         "layer0.texture": "",
-        "layer0.tint": [192, 197, 206], // 05
+        "layer0.tint": [230, 233, 240], // 06
         "layer0.opacity": 1,
         "layer0.inner_margin": [0,0],
         "blur": true
@@ -212,7 +212,7 @@
         "class": "scroll_bar_control",
         "attributes": ["horizontal"],
         "layer0.texture": "",
-        "layer0.tint": [192, 197, 206], // 05
+        "layer0.tint": [230, 233, 240], // 06
         "layer0.inner_margin": [0,0],
         "blur": true
     },
@@ -220,7 +220,7 @@
     {
         "class": "scroll_corner_control",
         "layer0.texture": "",
-        "layer0.tint": [192, 197, 206], // 05
+        "layer0.tint": [230, 233, 240], // 06
         "layer0.inner_margin": [0,0],
         "layer0.opacity": 1
     },

--- a/Spacegray.sublime-theme
+++ b/Spacegray.sublime-theme
@@ -201,7 +201,7 @@
     {
         "class": "scroll_bar_control",
         "layer0.texture": "",
-        "layer0.tint": [52, 61, 70], // 01
+        "layer0.tint": [35, 40, 48], // -01
         "layer0.opacity": 1,
         "layer0.inner_margin": [0,0],
         "blur": true
@@ -211,7 +211,7 @@
         "class": "scroll_bar_control",
         "attributes": ["horizontal"],
         "layer0.texture": "",
-        "layer0.tint": [52, 61, 70], // 01
+        "layer0.tint": [35, 40, 48], // -01
         "layer0.inner_margin": [0,0],
         "blur": true
     },
@@ -219,7 +219,7 @@
     {
         "class": "scroll_corner_control",
         "layer0.texture": "",
-        "layer0.tint": [52, 61, 70], // 01
+        "layer0.tint": [35, 40, 48], // -01
         "layer0.inner_margin": [0,0],
         "layer0.opacity": 1
     },
@@ -227,7 +227,7 @@
     {
         "class": "puck_control",
         "layer0.texture": "",
-        "layer0.tint": [60, 60, 60],
+        "layer0.tint": [52, 61, 70], // 01
         "layer0.opacity": 1,
         "layer0.inner_margin": [0,0],
         "content_margin": [6,0],


### PR DESCRIPTION
Here's a preview of what they look like with this change:

![Spacegray](https://f.cloud.github.com/assets/71916/1890453/27cc316c-7a2d-11e3-9f2e-2403cbfa85d4.png)
