### PR TITLE
Added support for transient tabs (italicized title)

### DIFF
--- a/Spacegray Eighties.sublime-theme
+++ b/Spacegray Eighties.sublime-theme
@@ -165,6 +165,11 @@
         "parents": [{"class": "tab_control","attributes": ["selected"]}],
         "fg": [232, 230, 223] // 06
     },
+    {
+        "class": "tab_label",
+        "attributes": ["transient"],
+        "font.italic": true
+    },
 
 //
 // FOLD BUTTONS

--- a/Spacegray Light.sublime-theme
+++ b/Spacegray Light.sublime-theme
@@ -166,6 +166,11 @@
         "parents": [{"class": "tab_control","attributes": ["selected"]}],
         "fg": [51, 61, 69] // 01
     },
+    {
+        "class": "tab_label",
+        "attributes": ["transient"],
+        "font.italic": true
+    },
 
 //
 // FOLD BUTTONS

--- a/Spacegray.sublime-theme
+++ b/Spacegray.sublime-theme
@@ -165,6 +165,11 @@
         "parents": [{"class": "tab_control","attributes": ["selected"]}],
         "fg": [223, 225, 232] // 06
     },
+    {
+        "class": "tab_label",
+        "attributes": ["transient"],
+        "font.italic": true
+    },
 
 //
 // FOLD BUTTONS


### PR DESCRIPTION
I'm using this great theme but I miss this little Sublime Text (default theme) feature, and maybe I'm not alone.

> In Sublime Text 3, single-clicking a file opens the preview in a special temporary tab. You can identify this tab by the italicized file name in the tab’s title. The preview tab is reused when you single-click another file.
> It’s an improvement over the old model where the preview took over the active tab because it allows you to peek at files while still referring to the files you’re actively working on.
> If you start editing the file, Sublime promotes the preview tab to a regular tab.
