### PR TITLE
Tab & Sidebar customization

### DIFF
--- a/Spacegray Eighties.sublime-theme
+++ b/Spacegray Eighties.sublime-theme
@@ -516,6 +516,16 @@
     },
     {
         "class": "sidebar_label",
+        "settings": ["spacegray_sidebar_font_small"],
+        "font.size": 10.0
+    },
+    {
+        "class": "sidebar_label",
+        "settings": ["spacegray_sidebar_font_normal"],
+        "font.size": 11.0
+    },
+    {
+        "class": "sidebar_label",
         "settings": ["spacegray_sidebar_font_large"],
         "font.size": 12.0
     },

--- a/Spacegray Light.sublime-theme
+++ b/Spacegray Light.sublime-theme
@@ -518,6 +518,16 @@
     },
     {
         "class": "sidebar_label",
+        "settings": ["spacegray_sidebar_font_small"],
+        "font.size": 10.0
+    },
+    {
+        "class": "sidebar_label",
+        "settings": ["spacegray_sidebar_font_normal"],
+        "font.size": 11.0
+    },
+    {
+        "class": "sidebar_label",
         "settings": ["spacegray_sidebar_font_large"],
         "font.size": 12.0
     },

--- a/Spacegray.sublime-theme
+++ b/Spacegray.sublime-theme
@@ -516,6 +516,16 @@
     },
     {
         "class": "sidebar_label",
+        "settings": ["spacegray_sidebar_font_small"],
+        "font.size": 10.0
+    },
+    {
+        "class": "sidebar_label",
+        "settings": ["spacegray_sidebar_font_normal"],
+        "font.size": 11.0
+    },
+    {
+        "class": "sidebar_label",
         "settings": ["spacegray_sidebar_font_large"],
         "font.size": 12.0
     },


### PR DESCRIPTION
Note that spacegray_tabs_font_xlarge will cause the font to be cut off; this is a [known issue](https://github.com/buymeasoda/soda-theme/issues/148) awaiting a fix in ST itself.
