### PR TITLE
Fix nasty XML parsing error every time Sublime opens

### DIFF
--- a/Spacegray/Widget - Spacegray Eighties.stTheme
+++ b/Spacegray/Widget - Spacegray Eighties.stTheme
@@ -2,39 +2,20 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 	<dict>
-		<key>author</key>
-		<string>Gadzhi Kharkharov</string>
-
-		<key>comment</key>
-		<string>Spacegray</string>
-		
-		<key>name</key>
-		<string>Spacegray Eighties</string>
-		
-		<key>settings</key>
-		<array>
-			<dict>
-				<key>settings</key>
-				<dict>
-					<key>background</key>
-					<string>#1E1E1E</string>
-		
-					<key>caret</key>
-					<string>#d3d0c8</string>
-		
-					<key>foreground</key>
-					<string>#d3d0c8</string>
-		
-					<key>invisibles</key>
-					<string>#747369</string>
-		
-					<key>selection</key>
-					<string>#515151</string>
-		
-					<key>selectionBorder</key>
-					<string>#51515100</string>
-				</dict>
-			</dict>
-		</array>
+		<key>author</key> 	<string>Gadzhi Kharkharov</string>
+		<key>comment</key> 	<string>Spacegray</string>
+		<key>name</key> 	<string>Spacegray Eighties</string>
+		<key>settings</key> <array>
+								<dict>
+									<key>settings</key> 	<dict>
+																<key>background</key> 		<string>#1E1E1E</string>
+																<key>caret</key> 			<string>#d3d0c8</string>
+																<key>foreground</key> 		<string>#d3d0c8</string>
+																<key>invisibles</key> 		<string>#747369</string>
+																<key>selection</key> 		<string>#515151</string>
+																<key>selectionBorder</key> 	<string>#51515100</string>
+															</dict>
+								</dict>
+							</array>
 	</dict>
 </plist>


### PR DESCRIPTION
Line 28 was duplicated, causing Sublime to error every time a new folder (or the Command Palette) was opened.
