### PR TITLE
Correct tab height

### DIFF
--- a/Spacegray Eighties.sublime-theme
+++ b/Spacegray Eighties.sublime-theme
@@ -15,7 +15,7 @@
         "tab_overlap": 0,
         "tab_width": 128,
         "tab_min_width": 48,
-        "tab_height": 28,
+        "tab_height": 26,
         "mouse_wheel_switch": false
     },
     {
@@ -1048,7 +1048,7 @@
     {
         "class": "tabset_control",
         "settings": ["spacegray_tabs_normal"],
-        "tab_height": 28
+        "tab_height": 26
     },
     {
         "class": "tabset_control",


### PR DESCRIPTION
When showing the sidebar the highlighted line of open files didn't align with the tabs by a difference of 2px. By reducing the height of both to 26px instead of 28px it's looks even cleaner.