### PR TITLE
Added suggestion to hide arrow icon clutter by the tabs in ST3

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,12 @@ Tabs width:
   "spacegray_sidebar_tree_xlarge": true
 ```
 
+#### Hide navigation icons in Sublime Text 3
+
+```json
+    "enable_tab_scrolling": false,
+```
+
 ***
 
 ### Thanks


### PR DESCRIPTION
before
![image](http://i.imgur.com/qmunHHC.png)

after
![image](http://i.imgur.com/KNWsPXE.png)