### PR TITLE
Change color for operators, add color for support.type

### DIFF
--- a/base16-eighties.dark.tmTheme
+++ b/base16-eighties.dark.tmTheme
@@ -13,6 +13,8 @@
 	<key>gutterSettings</key>
 	<dict>
 		<key>background</key>
+
+
 		<string>#393939</string>
 		<key>divider</key>
 		<string>#393939</string>
@@ -94,7 +96,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#d3d0c8</string>
+				<string>#cc99cc</string>
 			</dict>
 		</dict>
 		<dict>
@@ -178,7 +180,7 @@
 			<key>name</key>
 			<string>Support</string>
 			<key>scope</key>
-			<string>support.function</string>
+			<string>support.function, support.type</string>
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>


### PR DESCRIPTION
These changes make the base16-eighties.dark syntax highlighting more consistent when working with Python - at least in my opinion. Changes are very minor because the color scheme is already beautiful, I just fixed a few things that were bothering me.