### PR TITLE
Remove invalid commas

### DIFF
--- a/Spacegray Eighties.sublime-theme
+++ b/Spacegray Eighties.sublime-theme
@@ -659,7 +659,7 @@
     {
         "class": "icon_folder",
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.opacity": 1.0,
+        "layer0.opacity": 1.0
     },
     {
         "class": "icon_folder",
@@ -697,7 +697,7 @@
                 "Theme - Spacegray/assets/spinner7.png"
             ],
             "loop": true,
-            "frame_time": 0.075,
+            "frame_time": 0.075
         },
         "layer0.opacity": 0.6,
         "content_margin": [8, 8]
@@ -714,7 +714,7 @@
       "class": "icon_folder_dup",
       "parents":
       [{ "class": "tree_row", "attributes": ["hover"] }],
-      "layer0.opacity": 1,
+      "layer0.opacity": 1
     },
     // Sidebar file icons
     {

--- a/Spacegray Light.sublime-theme
+++ b/Spacegray Light.sublime-theme
@@ -661,7 +661,7 @@
     {
         "class": "icon_folder",
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.opacity": 1.0,
+        "layer0.opacity": 1.0
     },
     {
         "class": "icon_folder",
@@ -699,7 +699,7 @@
                 "Theme - Spacegray/assets/spinner7.png"
             ],
             "loop": true,
-            "frame_time": 0.075,
+            "frame_time": 0.075
         },
         "layer0.opacity": 0.6,
         "content_margin": [8, 8]
@@ -716,7 +716,7 @@
       "class": "icon_folder_dup",
       "parents":
       [{ "class": "tree_row", "attributes": ["hover"] }],
-      "layer0.opacity": 1,
+      "layer0.opacity": 1
     },
     // Sidebar file icons
     {

--- a/Spacegray Mocha.sublime-theme
+++ b/Spacegray Mocha.sublime-theme
@@ -659,7 +659,7 @@
     {
         "class": "icon_folder",
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.opacity": 1.0,
+        "layer0.opacity": 1.0
     },
     {
         "class": "icon_folder",
@@ -697,7 +697,7 @@
                 "Theme - Spacegray/assets/spinner7.png"
             ],
             "loop": true,
-            "frame_time": 0.075,
+            "frame_time": 0.075
         },
         "layer0.opacity": 0.6,
         "content_margin": [8, 8]
@@ -714,7 +714,7 @@
       "class": "icon_folder_dup",
       "parents":
       [{ "class": "tree_row", "attributes": ["hover"] }],
-      "layer0.opacity": 1,
+      "layer0.opacity": 1
     },
     // Sidebar file icons
     {

--- a/Spacegray Oceanic.sublime-theme
+++ b/Spacegray Oceanic.sublime-theme
@@ -659,7 +659,7 @@
     {
         "class": "icon_folder",
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.opacity": 1.0,
+        "layer0.opacity": 1.0
     },
     {
         "class": "icon_folder",
@@ -697,7 +697,7 @@
                 "Theme - Spacegray/assets/spinner7.png"
             ],
             "loop": true,
-            "frame_time": 0.075,
+            "frame_time": 0.075
         },
         "layer0.opacity": 0.6,
         "content_margin": [8, 8]
@@ -714,7 +714,7 @@
       "class": "icon_folder_dup",
       "parents":
       [{ "class": "tree_row", "attributes": ["hover"] }],
-      "layer0.opacity": 1,
+      "layer0.opacity": 1
     },
     // Sidebar file icons
     {

--- a/Spacegray.sublime-theme
+++ b/Spacegray.sublime-theme
@@ -660,7 +660,7 @@
     {
         "class": "icon_folder",
         "parents": [{"class": "tree_row","attributes": ["hover"]}],
-        "layer0.opacity": 1.0,
+        "layer0.opacity": 1.0
     },
     {
         "class": "icon_folder",
@@ -698,7 +698,7 @@
                 "Theme - Spacegray/assets/spinner7.png"
             ],
             "loop": true,
-            "frame_time": 0.075,
+            "frame_time": 0.075
         },
         "layer0.opacity": 0.6,
         "content_margin": [8, 8]
@@ -715,7 +715,7 @@
       "class": "icon_folder_dup",
       "parents":
       [{ "class": "tree_row", "attributes": ["hover"] }],
-      "layer0.opacity": 1,
+      "layer0.opacity": 1
     },
     // Sidebar file icons
     {


### PR DESCRIPTION
There were three invalid trailing commas in each theme file that were causing graphical problems with the sidebar and file tabs.