### PR TITLE
Treat 'keyword.operator.logical.python' as generic 'keyword'

### DIFF
--- a/base16-eighties.dark.tmTheme
+++ b/base16-eighties.dark.tmTheme
@@ -101,7 +101,7 @@
 			<key>name</key>
 			<string>Keywords</string>
 			<key>scope</key>
-			<string>keyword</string>
+			<string>keyword, keyword.operator.logical.python</string>
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>

--- a/base16-mocha.dark.tmTheme
+++ b/base16-mocha.dark.tmTheme
@@ -101,7 +101,7 @@
 			<key>name</key>
 			<string>Keywords</string>
 			<key>scope</key>
-			<string>keyword</string>
+			<string>keyword, keyword.operator.logical.python</string>
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>

--- a/base16-ocean.dark.tmTheme
+++ b/base16-ocean.dark.tmTheme
@@ -107,7 +107,7 @@
 			<key>name</key>
 			<string>Keywords</string>
 			<key>scope</key>
-			<string>keyword</string>
+			<string>keyword, keyword.operator.logical.python</string>
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>

--- a/base16-ocean.light.tmTheme
+++ b/base16-ocean.light.tmTheme
@@ -103,7 +103,7 @@
 			<key>name</key>
 			<string>Keywords</string>
 			<key>scope</key>
-			<string>keyword</string>
+			<string>keyword, keyword.operator.logical.python</string>
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>


### PR DESCRIPTION
This applies to *python only*.

The logical keywords `and` and `or` look out of place without the proper keyword highlighting, so I added a small exception to the 'keyword' scope.

**Note:** This does not affect the bitwise operators such as `&` and `|`.